### PR TITLE
Make jump buffer consumption in Player_ClimbJump conditional

### DIFF
--- a/Source/Entities/Monopticon.cs
+++ b/Source/Entities/Monopticon.cs
@@ -260,12 +260,10 @@ public class Monopticon : Lookout
 
     public static void Player_ClimbJump(On.Celeste.Player.orig_ClimbJump orig, Player self)
     {
-        Input.Jump.ConsumeBuffer();
-
-
         Monopticon mono = self.Scene.Tracker.GetEntity<Monopticon>();
         if (mono != null)
         {
+            Input.Jump.ConsumeBuffer();
             if (mono.arbInteract || !mono.blockJump)
             {
                 orig(self);


### PR DESCRIPTION
it's [the thing](https://discord.com/channels/403698615446536203/429775320720211968/1410844895853154338)

There might be a better solution (remove the buffer consumption entirely or do it later), but this at least means maps that aren't using Femto won't be impacted anymore