### PR TITLE
Add preserveSpeedOnThrow option to Evil Theo

### DIFF
--- a/Loenn/entities/EvilTheoCrystal.lua
+++ b/Loenn/entities/EvilTheoCrystal.lua
@@ -7,7 +7,8 @@ FemtoHelperEvilTheoCrystal.depth = 100
 FemtoHelperEvilTheoCrystal.placements = {
     name = "evil_theo_crystal",
     data = {
-        spriteOverride = ''
+        spriteOverride = '',
+        preserveSpeedOnThrow = false,
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -684,6 +684,10 @@ entities.FemtoHelper/SMWShell.attributes.description.outlineTextureType=The indi
 entities.FemtoHelper/SMWShell.attributes.description.upwardsThrowSpeed=The Shell's speed upon being thrown upwards.
 entities.FemtoHelper/SMWShell.attributes.description.dontRefill=Makes the Shell not refill the player's dash when bounced on.
 
+# Evil Theo Crystal
+entities.FemtoHelper/EvilTheoCrystal.placements.name.evil_theo_crystal=Evil Theo Crystal
+entities.FemtoHelper/EvilTheoCrystal.attributes.description.preserveSpeedOnThrow=If set, the player's horizontal speed is preserved when they are thrown by the Crystal.
+
 # ---------- Triggers ----------
 
 # Remote Particle Emitter Activator (please spare my soul its the best name i could come up with)

--- a/Source/Entities/EvilTheoCrystal.cs
+++ b/Source/Entities/EvilTheoCrystal.cs
@@ -51,7 +51,9 @@ public class EvilTheoCrystal : Actor
 
     public readonly VertexLight Light;
 
-    public EvilTheoCrystal(Vector2 position, string spriteOverride)
+    private readonly bool preserveSpeedOnThrow;
+
+    public EvilTheoCrystal(Vector2 position, string spriteOverride, bool preserveSpeedOnThrow = false)
         : base(position)
     {
         previousPosition = position;
@@ -59,6 +61,7 @@ public class EvilTheoCrystal : Actor
         Collider = new Hitbox(8f, 10f, -4f, -10f);
         Add(sprite = !string.IsNullOrEmpty(spriteOverride) ? GFX.SpriteBank.Create(spriteOverride) : FemtoModule.FemtoSpriteBank.Create("theo_crystal_evil"));
         sprite.Scale.X = -1f;
+        this.preserveSpeedOnThrow = preserveSpeedOnThrow;
         Add(Hold = new Holdable());
         Hold.PickupCollider = new Hitbox(16f, 22f, -8f, -16f);
         Hold.SlowFall = false;
@@ -80,7 +83,7 @@ public class EvilTheoCrystal : Actor
     }
 
     public EvilTheoCrystal(EntityData e, Vector2 offset)
-        : this(e.Position + offset, e.Attr("spriteOverride", ""))
+        : this(e.Position + offset, e.Attr("spriteOverride", ""), e.Bool("preserveSpeedOnThrow", false))
     {
     }
 
@@ -460,7 +463,12 @@ public class EvilTheoCrystal : Actor
             {
                 force.Y *= 1.5f;
                 Speed.Y -= 80;
-                p.Speed = force * 350f;
+                force *= 350f;
+                if (preserveSpeedOnThrow && Math.Sign(p.Speed.X) == Math.Sign(force.X))
+                {
+                    force.X = (float)Math.MaxMagnitude(force.X, p.Speed.X);
+                }
+                p.Speed = force;
             }
         }
         skipit:


### PR DESCRIPTION
I was mapping with Evil Theo (really cool entity btw) and found it weird that when you are thrown when having a lot of speed, that speed is just entirely lost and not preserved by either Theo or Madeline. So I added this option to let Madeline keep her speed.

Making Theo keep the speed instead might also make sense but to me this was more fun.

I also thought about giving some speed boost on top of your existing momentum but adding Evil Theo's normal boost to your existing speed is way too much and I wasn't sure which other value to pick. Adding an additional parameter for that felt like too much. So this seemed like the most consistent option. But if you'd rather have an additional speed boost, that'd be fine by me too. You'd just have to pick a value.