### PR TITLE
Fix PrismaticHelper crash + Add DetourConfig for future use

### DIFF
--- a/Source/CustomFancyText/ObfuscatedFancyText.cs
+++ b/Source/CustomFancyText/ObfuscatedFancyText.cs
@@ -69,12 +69,12 @@ public static class ObfuscatedFancyText
 
         ILLabel @continue = null;
 
-        //Logger.Debug(LogId, "Hi! I'm just an innocent little IL hook! Please don't kill me!");
-        
-
         // pain
+        // need to match the br too, because else prismatic's hook will throw us off
+        // once we find a match, go to the next ldloc.7 to go to the correct place
         if (!cursor.TryGotoNextBestFit(
-            MoveType.AfterLabel,
+            MoveType.Before,
+            static instr => instr.MatchBr(out _),
             static instr => instr.MatchLdloc(7),
             static instr => instr.MatchLdstr("savedata"),
             static instr => instr.MatchCallvirt<string>("Equals"),
@@ -84,11 +84,11 @@ public static class ObfuscatedFancyText
             return;
         }
 
+        cursor.GotoNext(MoveType.AfterLabel, static instr => instr.MatchLdloc(7));
         cursor.EmitLdarg0();
         cursor.EmitLdloc(7);
         cursor.EmitDelegate(TryMatchObfuscatedCommand);
         cursor.EmitBrtrue(@continue);
-        //Logger.Debug(LogId, il.ToString());
     }
 
     /// <summary>

--- a/Source/FemtoModule.cs
+++ b/Source/FemtoModule.cs
@@ -244,7 +244,7 @@ public class FemtoModule : EverestModule
         LimitRefill.Load();
         BoundRefill.Load();
         GenericSmwBlock.Load();
-        //ObfuscatedFancyText.Load();
+        ObfuscatedFancyText.Load();
         NewDistortedParallax.Load();
     }
 
@@ -282,7 +282,7 @@ public class FemtoModule : EverestModule
         LimitRefill.Unload();
         BoundRefill.Unload();
         GenericSmwBlock.Unload();
-        //ObfuscatedFancyText.Unload();
+        ObfuscatedFancyText.Unload();
         NewDistortedParallax.Unload();
     }
 

--- a/Source/FemtoModule.cs
+++ b/Source/FemtoModule.cs
@@ -61,6 +61,16 @@ public class FemtoModule : EverestModule
     // Only one alive module instance can exist at any given time.
     public static FemtoModule Instance;
     public static SpriteBank FemtoSpriteBank;
+
+    /// <summary>
+    ///   FemtoHelper's root <see cref="DetourConfig"/>, used for modifying hook order.
+    /// </summary>
+    /// <remarks>
+    ///   See <a href="https://monomod.dev/docs/RuntimeDetour/Usage.html">MonoMod docs</a>
+    ///   for usage and details on how <see cref="DetourConfig"/>s affect hook ordering.
+    /// </remarks>
+    internal static DetourConfig FemtoDetourRootConfig = new(nameof(FemtoHelper));
+
     public override Type SessionType => typeof(FemtoHelperSession);
     public static FemtoHelperSession Session => (FemtoHelperSession)Instance._Session;
 


### PR DESCRIPTION
Fixes the PrismaticHelper crash caused by its manipulator emitting another `ldloc 7`, throwing FemtoHelper's manipulator off.
The fix includes the `br` before the `ldloc.s` in the match predicates, then goes to the next `ldloc.s 7` for correct alignment.

Also adds a `DetourConfig` if any hook ordering shenanigans will be necessary in the future.