### PR TITLE
Support CJK characters in Plutonium Text

### DIFF
--- a/Source/PlutoniumText/CinematicText.cs
+++ b/Source/PlutoniumText/CinematicText.cs
@@ -147,6 +147,14 @@ public partial class CinematicText : Entity
         TextLayer layer = data.Enum("layer", data.Bool("hud", false) ? TextLayer.HUD : TextLayer.Gameplay);
         //Add(Text = new PlutoniumTextComponent(path, list, size, Hud ? PlutoniumText.TextLayer.HUD : PlutoniumText.TextLayer.Gameplay, BeforeRenderCallback, RenderCallback));
         Add(Text = new PlutoniumTextComponent(fontFilePath, layer, BeforeRenderCallback, RenderCallback, effectData, list, size));
+        
+        foreach (var n in Nodes)
+        {
+            if (n is PlutoniumTextNodes.Text text)
+            {
+                Text.Font.RegisterTextCharacters(text.StringText);
+            }
+        }
 
         Parallax = data.Float("parallax", 1);
 

--- a/Source/PlutoniumText/PlutoniumFont.cs
+++ b/Source/PlutoniumText/PlutoniumFont.cs
@@ -108,13 +108,8 @@ public struct PlutoniumFont
         public override int Width => width;
         public override int Height => height;
 
-        public TextCharacter(char character)
+        public TextCharacter(PlutoniumFont parent, char character, PixelFontCharacter data)
         {
-            if (!ActiveFont.FontSize.Characters.TryGetValue(character, out PixelFontCharacter data))
-            {
-                throw new Exception($"Active font does not contain character '{character}'!");
-            }
-
             Letter = character;
 
             MTexture texture = data.Texture;
@@ -131,8 +126,8 @@ public struct PlutoniumFont
             PreDrawOffset = new Point(xOffset, 0);
             PostDrawOffset = new Point(postXOffset, 0);
 
-            Outline = VirtualContent.CreateRenderTarget("extended_char_" + (int)character + "_outline", width + 2, height + 2);
-            Shadow = VirtualContent.CreateRenderTarget("extended_char_" + (int)character + "_shadow", width + 2, height + 2);
+            Outline = VirtualContent.CreateRenderTarget(parent.SourcePath + "_" + character + "_outline", width + 2, height + 2);
+            Shadow = VirtualContent.CreateRenderTarget(parent.SourcePath + "_" + character + "_shadow", width + 2, height + 2);
 
             GraphicsDevice g = Engine.Graphics.GraphicsDevice;
 
@@ -340,9 +335,9 @@ public struct PlutoniumFont
     {
         foreach (var c in str)
         {
-            if (!Chars.ContainsKey(c))
+            if (!Chars.ContainsKey(c) && ActiveFont.FontSize.Characters.TryGetValue(c, out PixelFontCharacter data))
             {
-                Chars.Add(c, new TextCharacter(c));
+                Chars.Add(c, new TextCharacter(this, c, data));
             }
         }
     }

--- a/Source/PlutoniumText/PlutoniumFont.cs
+++ b/Source/PlutoniumText/PlutoniumFont.cs
@@ -9,7 +9,7 @@ public struct PlutoniumFont
 {
     public static Dictionary<string, PlutoniumFont> FontCache { get; private set; } = [];
 
-    public struct Character
+    public abstract class Character
     {
         public static BlendState AlphaSubtract = new()
         {
@@ -21,15 +21,36 @@ public struct PlutoniumFont
             AlphaBlendFunction = BlendFunction.ReverseSubtract
         };
 
-        public readonly Rectangle SourceRect;
         public Point PreDrawOffset;
         public Point PostDrawOffset;
-        public MTexture Sprite;
         public VirtualRenderTarget Outline;
         public VirtualRenderTarget Shadow;
         public Dictionary<char, Point> KerningData = [];
 
-        public Character(PlutoniumFont parent, char character, MTexture source, Rectangle rect, Point preOffset, Point postOffset)
+        public abstract int Width { get; }
+        public abstract int Height { get; }
+
+        public abstract void DrawCharacter(Vector2 position, Color color, float scale, SpriteEffects seffect);
+
+        public Point GetKerning(char afterThisChar)
+        {
+            if (KerningData.TryGetValue(afterThisChar, out var result))
+            {
+                return result;
+            }
+            else return Point.Zero;
+        }
+    }
+
+    public class SpriteCharacter : Character
+    {
+        public readonly Rectangle SourceRect;
+        public MTexture Sprite;
+        
+        public override int Width => Sprite.Width;
+        public override int Height => Sprite.Height;
+
+        public SpriteCharacter(PlutoniumFont parent, char character, MTexture source, Rectangle rect, Point preOffset, Point postOffset)
         {
             Sprite = source.GetSubtexture(rect);
             SourceRect = rect;
@@ -68,13 +89,89 @@ public struct PlutoniumFont
             Draw.SpriteBatch.End();
         }
 
-        public Point GetKerning(char afterThisChar)
+        public override void DrawCharacter(Vector2 position, Color color, float scale, SpriteEffects seffect)
         {
-            if (KerningData.TryGetValue(afterThisChar, out var result))
+            Sprite.Draw(position, Vector2.Zero, color, scale, 0f, seffect);
+        }
+    }
+
+    public class TextCharacter : Character
+    {
+        private const float Scale = 1/3f;
+        
+        public char Letter;
+        private Vector2 charOffset;
+
+        private readonly int width;
+        private readonly int height;
+        
+        public override int Width => width;
+        public override int Height => height;
+
+        public TextCharacter(char character)
+        {
+            if (!ActiveFont.FontSize.Characters.TryGetValue(character, out PixelFontCharacter data))
             {
-                return result;
+                throw new Exception($"Active font does not contain character '{character}'!");
             }
-            else return Point.Zero;
+
+            Letter = character;
+
+            MTexture texture = data.Texture;
+            width = (int) Math.Ceiling(texture.Width * Scale);
+            height = (int) Math.Ceiling(texture.Height * Scale);
+            height += height % 2;
+
+            int xOffset = (int) (data.XOffset * Scale);
+            int yOffset = (int) (data.YOffset * Scale);
+            charOffset = new Vector2(xOffset, yOffset);
+            
+            int postXOffset = (int) Math.Ceiling((data.XAdvance - data.XOffset - texture.Width) * Scale);
+
+            PreDrawOffset = new Point(xOffset, 0);
+            PostDrawOffset = new Point(postXOffset, 0);
+
+            Outline = VirtualContent.CreateRenderTarget("extended_char_" + (int)character + "_outline", width + 2, height + 2);
+            Shadow = VirtualContent.CreateRenderTarget("extended_char_" + (int)character + "_shadow", width + 2, height + 2);
+
+            GraphicsDevice g = Engine.Graphics.GraphicsDevice;
+
+            //do outline first
+
+            g.SetRenderTarget(Outline);
+            g.Clear(Color.Transparent);
+
+            Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, Matrix.Identity);
+            for (int i = -1; i <= 1; i++)
+            {
+                for (int j = -1; j <= 1; j++)
+                {
+                    ActiveFont.Draw(Letter, Vector2.One + new Vector2(i, j) - charOffset, Vector2.Zero, new Vector2(Scale), Color.White);
+                }
+            }
+            Draw.SpriteBatch.End();
+
+            Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, AlphaSubtract, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, Matrix.Identity);
+            ActiveFont.Draw(Letter, Vector2.One - charOffset, Vector2.Zero, new Vector2(Scale), Color.White);
+            Draw.SpriteBatch.End();
+
+            //then do shadow
+
+            g.SetRenderTarget(Shadow);
+            g.Clear(Color.Transparent);
+
+            Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, Matrix.Identity);
+            ActiveFont.Draw(Letter, Vector2.One + Vector2.One - charOffset, Vector2.Zero, new Vector2(Scale), Color.White);
+            Draw.SpriteBatch.End();
+
+            Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, AlphaSubtract, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, Matrix.Identity);
+            ActiveFont.Draw(Letter, Vector2.One - charOffset, Vector2.Zero, new Vector2(Scale), Color.White);
+            Draw.SpriteBatch.End();
+        }
+
+        public override void DrawCharacter(Vector2 position, Color color, float scale, SpriteEffects seffect)
+        {
+            ActiveFont.Draw(Letter, position - charOffset, Vector2.Zero, new Vector2(scale * Scale), color);
         }
     }
 
@@ -100,7 +197,7 @@ public struct PlutoniumFont
 
             for(int i = 0; i < CharList.Length; i++)
             {
-                Chars.Add(CharList[i], new Character(this, CharList[i], SourceTexture, new Rectangle((int)legacySize.X * i, 0, (int)legacySize.X, (int)legacySize.Y), Point.Zero, Point.Zero));
+                Chars.Add(CharList[i], new SpriteCharacter(this, CharList[i], SourceTexture, new Rectangle((int)legacySize.X * i, 0, (int)legacySize.X, (int)legacySize.Y), Point.Zero, Point.Zero));
             }
 
             FontCache.Add(path, this);
@@ -162,7 +259,7 @@ public struct PlutoniumFont
 
             Character chr;
 
-            Chars.Add(id, chr = new Character(this, id, SourceTexture, source, pre, post));
+            Chars.Add(id, chr = new SpriteCharacter(this, id, SourceTexture, source, pre, post));
 
             foreach(XmlElement kerning in character.GetElementsByTagName("CharSpecificOffset"))
             {
@@ -226,16 +323,27 @@ public struct PlutoniumFont
                     size += ch2.GetKerning(before).ToVector2();
                 }
                 else firstchar = false;
-                size += new Vector2(ch2.Sprite.Width, 0) + ch2.PreDrawOffset.ToVector2() + ch2.PostDrawOffset.ToVector2() + (Vector2.UnitX * extraSpacing);
+                size += new Vector2(ch2.Width, 0) + ch2.PreDrawOffset.ToVector2() + ch2.PostDrawOffset.ToVector2() + (Vector2.UnitX * extraSpacing);
 
-                if(ch2.Sprite.Height > tallestChar)
+                if(ch2.Height > tallestChar)
                 {
-                    tallestChar = ch2.Sprite.Height;
+                    tallestChar = ch2.Height;
                 }
 
                 before = c;
             }
         }
         return size + (Vector2.UnitY * tallestChar);
+    }
+
+    public void RegisterTextCharacters(string str)
+    {
+        foreach (var c in str)
+        {
+            if (!Chars.ContainsKey(c))
+            {
+                Chars.Add(c, new TextCharacter(c));
+            }
+        }
     }
 }

--- a/Source/PlutoniumText/PlutoniumTextComponent.cs
+++ b/Source/PlutoniumText/PlutoniumTextComponent.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using System.Net.Mime;
 using static Celeste.Mod.FemtoHelper.PlutoniumFont;
 
 namespace Celeste.Mod.FemtoHelper;
@@ -147,7 +148,7 @@ public class PlutoniumTextComponent : Component
 
                     Vector2 charpos = pos + offset;
 
-                    if (flipped) charpos -= Vector2.UnitX * origChar.Sprite.Width;
+                    if (flipped) charpos -= Vector2.UnitX * origChar.Width;
 
                     if (!EffectData.Empty && i < effectOffsets.Count) charpos += effectOffsets[i];
 
@@ -167,7 +168,7 @@ public class PlutoniumTextComponent : Component
                         Draw.SpriteBatch.Draw(@char.Outline, new Rectangle((int)MathF.Round(charpos.X - scale), (int)(MathF.Round(charpos.Y - scale) - (justify.Y * @char.Shadow.Height * scale)), (int)(@char.Shadow.Width * scale), (int)(@char.Shadow.Height * scale)), null, color, 0, Vector2.Zero, seffect, 0f);
                     }
 
-                    offset += ((Vector2.UnitX * (origChar.Sprite.Width + extraSpacing)) + origChar.PostDrawOffset.ToVector2()) * scale * factor;
+                    offset += ((Vector2.UnitX * (origChar.Width + extraSpacing)) + origChar.PostDrawOffset.ToVector2()) * scale * factor;
                 }
 
                 before = origc;
@@ -213,14 +214,14 @@ public class PlutoniumTextComponent : Component
                         color = mainColor.Multiply(RainbowHelper.GetRainbowColorAt(Scene, EffectData.RainbowAnchor + (offset / (scale == 0 ? float.Epsilon : scale))));
                     }
 
-                    if (flipped) charpos -= Vector2.UnitX * origChar.Sprite.Width;
+                    if (flipped) charpos -= Vector2.UnitX * origChar.Width;
 
                     if (!EffectData.Empty && i < effectOffsets.Count) charpos += effectOffsets[i];
 
-                    @char.Sprite.Draw((charpos - (justify.Y * @char.Shadow.Height * Vector2.UnitY * scale)).Round(), Vector2.Zero, color, scale, 0f, seffect);
+                    @char.DrawCharacter((charpos - (justify.Y * @char.Shadow.Height * Vector2.UnitY * scale)).Round(), color, scale, seffect);
                     //Draw.Rect((charpos - (justify.Y * @char.Shadow.Height * Vector2.UnitY * scale)).Floor(), 1, 1, Color.Red);
 
-                    offset += ((Vector2.UnitX * (origChar.Sprite.Width + extraSpacing)) + origChar.PostDrawOffset.ToVector2()) * scale * factor;
+                    offset += ((Vector2.UnitX * (origChar.Width + extraSpacing)) + origChar.PostDrawOffset.ToVector2()) * scale * factor;
                 }
 
                 before = origc;

--- a/Source/PlutoniumText/SimpleText.cs
+++ b/Source/PlutoniumText/SimpleText.cs
@@ -1,5 +1,6 @@
 using Celeste.Mod.FemtoHelper.PlutoniumText;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Celeste.Mod.FemtoHelper.Entities;
@@ -62,6 +63,15 @@ public partial class SimpleText : Entity
 
         TextLayer layer = data.Enum("layer", data.Bool("hud", false) ? TextLayer.HUD : TextLayer.Gameplay);
         Add(Text = new PlutoniumTextComponent(fontFilePath, layer, null, RenderCallback, new(), list, size));
+        
+        foreach (var n in Nodes)
+        {
+            if (n is PlutoniumTextNodes.Text text)
+            {
+                Text.Font.RegisterTextCharacters(text.StringText);
+            }
+        }
+        
         Parallax = data.Float("parallax", 1);
 
         HudCanZoom = data.Bool("hudZoomSupport", false);


### PR DESCRIPTION
Support the Chinese, Japanese and Korean characters handled by Celeste, i.e. the characters displayable by the active font selected.

Abstract the Character struct into two implementations : 
- SpriteCharacter for the current implementation with Sprites and XMLs
- TextCharacter for rendering characters using the ActiveFont scaled down by a factor 3 (In Celeste's Noto font, characters are usually about 40px high, so scale by a factor 3 bring it to about example plutonium text size without too much pixelating it)

This abstracts the Width, Height and Drawing method of the characters replacing Sprite.Width, Sprite.Height and Sprite.Draw

It creates the characters during the SimpleText/CinematicText ctor by looping over the characters in the text nodes for unrecognized characters, putting TextCharacter of each one in Font.Chars

<img width="1280" height="720" alt="Chinese Screenshot" src="https://github.com/user-attachments/assets/8499b950-2260-4957-b160-6932efa7db01" />
<img width="1280" height="720" alt="Korean Screenshot" src="https://github.com/user-attachments/assets/853519c8-ca19-414d-9444-9f68fb81022e" />
