### PR TITLE
Fix scaling issue on CJK characters

### DIFF
--- a/Source/PlutoniumText/PlutoniumFont.cs
+++ b/Source/PlutoniumText/PlutoniumFont.cs
@@ -100,6 +100,7 @@ public struct PlutoniumFont
         private const float Scale = 1/3f;
         
         public char Letter;
+        private VirtualRenderTarget LetterSprite;
         private Vector2 charOffset;
 
         private readonly int width;
@@ -128,6 +129,7 @@ public struct PlutoniumFont
 
             Outline = VirtualContent.CreateRenderTarget(parent.SourcePath + "_" + character + "_outline", width + 2, height + 2);
             Shadow = VirtualContent.CreateRenderTarget(parent.SourcePath + "_" + character + "_shadow", width + 2, height + 2);
+            LetterSprite = VirtualContent.CreateRenderTarget(parent.SourcePath + "_" + character + "_letter", width, height);
 
             GraphicsDevice g = Engine.Graphics.GraphicsDevice;
 
@@ -162,11 +164,18 @@ public struct PlutoniumFont
             Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, AlphaSubtract, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, Matrix.Identity);
             ActiveFont.Draw(Letter, Vector2.One - charOffset, Vector2.Zero, new Vector2(Scale), Color.White);
             Draw.SpriteBatch.End();
+
+            g.SetRenderTarget(LetterSprite);
+            g.Clear(Color.Transparent);
+
+            Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, Matrix.Identity);
+            ActiveFont.Draw(Letter, Vector2.Zero - charOffset, Vector2.Zero, new Vector2(Scale), Color.White);
+            Draw.SpriteBatch.End();
         }
 
         public override void DrawCharacter(Vector2 position, Color color, float scale, SpriteEffects seffect)
         {
-            ActiveFont.Draw(Letter, position - charOffset, Vector2.Zero, new Vector2(scale * Scale), color);
+            Draw.SpriteBatch.Draw(LetterSprite, position, new Rectangle(0, 0, width, height), color, 0, Vector2.Zero, scale, seffect, 0f);
         }
     }
 


### PR DESCRIPTION
Currently scaling (or using the hud option since it does scaling) scales the character offset and make the character have a way bigger resolution than the shadow, outline, and overall size it should have.
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/ed850871-428b-486a-8870-83707877b976" />

Drawing TextCharacters beforehand in a VirtualRenderTarget then scaling it when drawing (the same way it's done for outlines and shadows) fixes both issues
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/113392fc-f769-4921-8290-499d37c7f71b" />
